### PR TITLE
Makefile tweaks

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,6 +8,8 @@ EMACS="$(shell which emacs)" -Q -batch -L .
 ELS = csharp-mode.el csharp-mode-tests.el
 ELCS = $(ELS:.el=.elc)
 
+all: $(ELCS) test package
+
 package: $(PACKAGE_DIR)
 	tar cvf ../$(PACKAGE_NAME).tar --exclude="*#" --exclude="*~" --exclude="*tests*" --exclude="test-files" --exclude "*-pkg.el.template*" --exclude="makefile" --exclude="run-travis-ci.sh" -C $(PACKAGE_DIR)/.. $(PACKAGE_NAME)
 
@@ -21,8 +23,6 @@ test:
 
 %.elc: %.el
 	$(EMACS) -f batch-byte-compile $<
-
-all: $(ELCS) test package
 
 clean:
 	rm -f ../$(PACKAGE_NAME).tar

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ PACKAGE_NAME:=$(PACKAGE_SHORTNAME)-$(VERSION)
 PACKAGE_DIR:=./.tmp/$(PACKAGE_NAME)
 #PACKAGE_DIR:=/tmp/$(PACKAGE_NAME)
 
-EMACS=$(shell which emacs) -Q -batch -L .
+EMACS="$(shell which emacs)" -Q -batch -L .
 ELS = csharp-mode.el csharp-mode-tests.el
 ELCS = $(ELS:.el=.elc)
 

--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -11,4 +11,4 @@ echo "ECUKES_EMACS = $ECUKES_EMACS"
 echo
 
 # bytecompile, tests, package
-make all 
+make


### PR DESCRIPTION
My emacs is installed to `%PROGRAMFILES%`. Quoting is necessary to support that if it is to be invoked with its full path…though I don’t know why that is necessary, honestly.

Also, normally, the default `Makefile` target is `all`. The only way to specify this is to have `all` be the first listed target in the `Makefile`.