### PR TITLE
Support compilation output from msbuild /maxcpucount (/m).

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -49,21 +49,48 @@
       (should
        (equal buffer1 buffer2)))))
 
+(defun list-repeat-once (mylist)
+  (append mylist mylist))
+
 (ert-deftest build-warnings-and-errors-are-parsed ()
   (dolist (test-case
-	   `(("./test-files/msbuild-warning.txt" ,csharp-compilation-re-msbuild-warning 3)
-	     ("./test-files/msbuild-error.txt" ,csharp-compilation-re-msbuild-error 1)
-	     ("./test-files/xbuild-warning.txt" ,csharp-compilation-re-xbuild-warning 5)
-	     ("./test-files/xbuild-error.txt" ,csharp-compilation-re-xbuild-error 1)
+	   `(("./test-files/msbuild-warning.txt" ,csharp-compilation-re-msbuild-warning 8
+              ,(list-repeat-once
+                '("Class1.cs"
+                  "Folder\\Class1.cs"
+                  "Program.cs"
+                  "Program.cs")))
+	     ("./test-files/msbuild-error.txt" ,csharp-compilation-re-msbuild-error 2
+              ,(list-repeat-once
+                '("Folder\\Class1.cs")))
+             ("./test-files/msbuild-concurrent-warning.txt" ,csharp-compilation-re-msbuild-warning 2
+              ,(list-repeat-once
+                '("Program.cs")))
+             ("./test-files/msbuild-concurrent-error.txt" ,csharp-compilation-re-msbuild-error 2
+              ,(list-repeat-once
+                '("Program.cs")))
+	     ("./test-files/xbuild-warning.txt" ,csharp-compilation-re-xbuild-warning 10
+              ,(list-repeat-once
+                '("/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ClassLibrary1/Class1.cs"
+                  "/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ClassLibrary1/Folder/Class1.cs"
+                  "/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ConsoleApplication1/Program.cs"
+                  "/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ConsoleApplication1/Program.cs"
+                  "/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ConsoleApplication1/Program.cs")))
+	     ("./test-files/xbuild-error.txt" ,csharp-compilation-re-xbuild-error 2
+              ,(list-repeat-once
+                '("/Users/jesseblack/Dropbox/barfapp/ConsoleApplication1/ClassLibrary1/Folder/Class1.cs")))
 	     ))
 
     (let* ((file-name (car test-case))
 	   (regexp    (cadr test-case))
 	   (times     (caddr test-case))
+           (matched-file-names (cadddr test-case))
 	   (find-file-hook '()) ;; avoid vc-mode file-hooks when opening!
 	   (buffer (find-file-read-only file-name)))
       (dotimes (number times)
-	(re-search-forward regexp))
+	(re-search-forward regexp)
+        (should
+         (equal (nth number matched-file-names) (match-string 1))))
       (kill-buffer buffer))))
 
 ;;(ert-run-tests-interactively t)

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -4150,14 +4150,14 @@ The return value is meaningless, and is ignored by cc-mode.
 
 (defconst csharp-compilation-re-msbuild-error
   (concat
-   "^[[:blank:]]*"
+   "^[[:blank:]]*\\(?:[[:digit:]]+>\\)?"
    "\\([^(\r\n)]+\\)(\\([0-9]+\\)\\(?:,\\([0-9]+\\)\\)?): "
    "error [[:alnum:]]+: [^[\r\n]+\\[\\([^]\r\n]+\\)\\]$")
   "Regexp to match compilation error from msbuild.")
 
 (defconst csharp-compilation-re-msbuild-warning
   (concat
-   "^[[:blank:]]*"
+   "^[[:blank:]]*\\(?:[[:digit:]]+>\\)?"
    "\\([^(\r\n)]+\\)(\\([0-9]+\\)\\(?:,\\([0-9]+\\)\\)?): "
    "warning [[:alnum:]]+: [^[\r\n]+\\[\\([^]\r\n]+\\)\\]$")
   "Regexp to match compilation warning from msbuild.")

--- a/test-files/msbuild-concurrent-error.txt
+++ b/test-files/msbuild-concurrent-error.txt
@@ -1,0 +1,30 @@
+-*- mode: compilation; default-directory: "~/Documents/Visual Studio 2015/Projects/ConsoleApplication3/ConsoleApplication3/" -*-
+Compilation started at Mon Apr 20 01:44:35
+
+bash -c "for m in *akefile; do break; done; if [[ ${m} != \"*akefile\" ]]; then PATH=\"${PATH}:/c/Program Files (x86)/MSBuild/14.0/Bin:/c/Program Files/Emacs/bin\" make; else set -o pipefail; 'c:/Program Files (x86)/MSBuild/14.0/Bin/MSBuild.exe' //m; fi"
+Microsoft (R) Build Engine version 14.0.22609.0
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Build started 2015-04-20 01:44:36.
+The target "AfterGenerateAppxManifest" listed in an AfterTargets attribute at "C:\Program Files (x86)\MSBuild\Microsoft\.NetNative\Microsoft.NetNative.targets (60,11)" does not exist in the project, and will be ignored.
+The target "AfterGenerateAppxManifest" listed in an AfterTargets attribute at "C:\Program Files (x86)\MSBuild\Microsoft\.NetNative\Microsoft.NetNative.targets (108,11)" does not exist in the project, and will be ignored.
+     1>Project "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" on node 1 (default targets).
+     1>GenerateTargetFrameworkMonikerAttribute:
+       Skipping target "GenerateTargetFrameworkMonikerAttribute" because all output files are up-to-date with respect to the input files.
+       CoreCompile:
+         C:\Program Files (x86)\MSBuild\14.0\bin\csc2.exe /noconfig /nowarn:1701,1702 /nostdlib+ /platform:anycpu32bitpreferred /errorreport:prompt /warn:4 /define:DEBUG;TRACE /highentropyva+ /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\Microsoft.CSharp.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.DataSetExtensions.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.Linq.dll" /debug+ /debug:full /filealign:512 /optimize- /out:obj\Debug\ConsoleApplication3.exe /ruleset:"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\\Rule Sets\MinimumRecommendedRules.ruleset" /subsystemversion:6.00 /target:exe /utf8output Program.cs Properties\AssemblyInfo.cs "C:\Users\ohnob\AppData\Local\Temp\.NETFramework,Version=v4.5.AssemblyAttributes.cs"
+     1>Program.cs(13,2): error CS1002: ; expected [c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj]
+     1>Done Building Project "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" (default targets) -- FAILED.
+
+Build FAILED.
+
+       "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" (default target) (1) ->
+       (CoreCompile target) -> 
+         Program.cs(13,2): error CS1002: ; expected [c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj]
+
+    0 Warning(s)
+    1 Error(s)
+
+Time Elapsed 00:00:00.15
+
+Compilation exited abnormally with code 1 at Mon Apr 20 01:44:36

--- a/test-files/msbuild-concurrent-warning.txt
+++ b/test-files/msbuild-concurrent-warning.txt
@@ -1,0 +1,36 @@
+-*- mode: compilation; default-directory: "~/Documents/Visual Studio 2015/Projects/ConsoleApplication3/ConsoleApplication3/" -*-
+Compilation started at Mon Apr 20 01:44:21
+
+bash -c "for m in *akefile; do break; done; if [[ ${m} != \"*akefile\" ]]; then PATH=\"${PATH}:/c/Program Files (x86)/MSBuild/14.0/Bin:/c/Program Files/Emacs/bin\" make; else set -o pipefail; 'c:/Program Files (x86)/MSBuild/14.0/Bin/MSBuild.exe' //m; fi"
+Microsoft (R) Build Engine version 14.0.22609.0
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Build started 2015-04-20 01:44:22.
+The target "AfterGenerateAppxManifest" listed in an AfterTargets attribute at "C:\Program Files (x86)\MSBuild\Microsoft\.NetNative\Microsoft.NetNative.targets (60,11)" does not exist in the project, and will be ignored.
+The target "AfterGenerateAppxManifest" listed in an AfterTargets attribute at "C:\Program Files (x86)\MSBuild\Microsoft\.NetNative\Microsoft.NetNative.targets (108,11)" does not exist in the project, and will be ignored.
+     1>Project "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" on node 1 (default targets).
+     1>GenerateTargetFrameworkMonikerAttribute:
+       Skipping target "GenerateTargetFrameworkMonikerAttribute" because all output files are up-to-date with respect to the input files.
+       CoreCompile:
+         C:\Program Files (x86)\MSBuild\14.0\bin\csc2.exe /noconfig /nowarn:1701,1702 /nostdlib+ /platform:anycpu32bitpreferred /errorreport:prompt /warn:4 /define:DEBUG;TRACE /highentropyva+ /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\Microsoft.CSharp.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.DataSetExtensions.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Data.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.dll" /reference:"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.Linq.dll" /debug+ /debug:full /filealign:512 /optimize- /out:obj\Debug\ConsoleApplication3.exe /ruleset:"C:\Program Files (x86)\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\\Rule Sets\MinimumRecommendedRules.ruleset" /subsystemversion:6.00 /target:exe /utf8output Program.cs Properties\AssemblyInfo.cs "C:\Users\ohnob\AppData\Local\Temp\.NETFramework,Version=v4.5.AssemblyAttributes.cs"
+     1>Program.cs(13,10): warning CS1030: #warning: 'asdf' [c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj]
+       _CopyAppConfigFile:
+       Skipping target "_CopyAppConfigFile" because all output files are up-to-date with respect to the input files.
+       CopyFilesToOutputDirectory:
+         Copying file from "obj\Debug\ConsoleApplication3.exe" to "bin\Debug\ConsoleApplication3.exe".
+         ConsoleApplication3 -> c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\bin\Debug\ConsoleApplication3.exe
+         Copying file from "obj\Debug\ConsoleApplication3.pdb" to "bin\Debug\ConsoleApplication3.pdb".
+     1>Done Building Project "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" (default targets).
+
+Build succeeded.
+
+       "c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj" (default target) (1) ->
+       (CoreCompile target) -> 
+         Program.cs(13,10): warning CS1030: #warning: 'asdf' [c:\Users\ohnob\Documents\Visual Studio 2015\Projects\ConsoleApplication3\ConsoleApplication3\ConsoleApplication3.csproj]
+
+    1 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:00.20
+
+Compilation finished at Mon Apr 20 01:44:22


### PR DESCRIPTION
Lines of output from concurrent msbuild builds are, by default,
prefixed with something like "1>", where "1" is the number of the
msbuild node that caused the output to appear. This must be skipped
for the filename to be properly recognized.

This expands the regexp matching tests to check that the discovered
relative path is, indeed, the expected relative path. It also expands
the tests to account for all of the error/warning messages, including
the repeated messages summary.