### PR TITLE
Use cl-lib equivalents for incf and decf

### DIFF
--- a/csharp-mode-pkg.el.template
+++ b/csharp-mode-pkg.el.template
@@ -1,4 +1,5 @@
 (define-package
     "csharp-mode"
     "VERSION"
-    "C# mode derived mode")
+    "C# mode derived mode"
+    '((cl-lib "0.5")))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -288,7 +288,7 @@
 (require 'cc-mode)
 
 ;; cc-defs in emacs 24.4 depends on cl-macroexpand-all, but does not load 'cl itself.
-(require 'cl)
+(require 'cl-lib)
 
 ;; ==================================================================
 ;; c# upfront stuff
@@ -2139,7 +2139,7 @@ Upon entry, it's assumed that the parens included in S.
 	      (setq state 0))
              ;; non-ws indicates the type spec is beginning
              (t
-              (incf i)
+              (cl-incf i)
               (setq state 3
                     need-type nil
                     nesting 0
@@ -2149,9 +2149,9 @@ Upon entry, it's assumed that the parens included in S.
            ;; slurping type
            ((= state 3)
             (cond
-             ((= ?> c) (incf nesting))
+             ((= ?> c) (cl-incf nesting))
              ((= ?< c)
-              (decf nesting)
+              (cl-decf nesting)
               (setq need-type t))
 
              ;; ws or comma maybe signifies the end of the typespec
@@ -2177,9 +2177,9 @@ Upon entry, it's assumed that the parens included in S.
              ((string-match "[ \t\f\v\n\r]" cs)
               t)
 
-             ((= 93 c) (incf nesting)) ;; sq brack
+             ((= 93 c) (cl-incf nesting)) ;; sq brack
              ((= 91 c)  ;; open sq brack
-              (decf nesting))
+              (cl-decf nesting))
 
              ;; handle this (extension methods), out, ref, params
              ((and (>= i 5)
@@ -2216,7 +2216,7 @@ Upon entry, it's assumed that the parens included in S.
 	      t)))
            )
 
-          (decf i))
+          (cl-decf i))
 
         (if (and (= state 3) (= nesting 0))
             (setq new (cons (substring s2 i ix2) new)))
@@ -2262,7 +2262,7 @@ For this input:
        ((and (= state 1) (or (= c 9) (= c 32)))
         (setq result (substring sig (1+ i))
               i 0)))
-      (decf i))
+      (cl-decf i))
     result))
 
 
@@ -2417,7 +2417,7 @@ more open-curlies are found.
 
               ;; count the using statements
               (while (re-search-forward (csharp--regexp 'using-stmt) limit t)
-                (incf count))
+                (cl-incf count))
 
               (setq marquis (if (eq count 1) "using (1)"
                               (format "usings (%d)" count)))
@@ -2662,7 +2662,7 @@ this fn will be something like this:
                        (xelt (assoc topic new)))
                   (funcall helper (cdr list)
                            (if xelt
-                               (progn (incf (cdr xelt)) new)
+                               (progn (cl-incf (cdr xelt)) new)
                              (cons (cons topic 1) new))))))))
     (nreverse (funcall helper list nil))))
 
@@ -2731,7 +2731,7 @@ See also, `string-lastindexof'
       (setq c2 (aref s i))
       (if (= c c2)
           (setq ix i))
-      (incf i))
+      (cl-incf i))
     ix))
 
 (defun string-lastindexof (s c)
@@ -2747,7 +2747,7 @@ See also, `string-indexof'
       (setq c2 (aref s i))
       (if (= c c2)
           (setq ix i))
-      (decf i))
+      (cl-decf i))
     ix))
 
 
@@ -2825,7 +2825,7 @@ Returns a new list, containing sublists.
                 label (concat "from " (csharp--imenu-submenu-label (caar this-chunk) base-name))
                 new (cons (cons label this-chunk) new)
                 len (- len chunksz))
-          (incf i))
+          (cl-incf i))
         new)))))
 
 


### PR DESCRIPTION
Mostly self-explanatory.  Not sure on the change to the package template file, I did a quick search on packages I've installed and found several to declare a dependency on the GNU ELPA version of cl-lib instead of Emacs 24.1.