### PR TITLE
Apply bug#18845 workaround

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -288,6 +288,11 @@
 (require 'cc-mode)
 (require 'cl-lib)
 
+;; Work around emacs bug#18845
+(eval-when-compile
+  (when (and (= emacs-major-version 24) (>= emacs-minor-version 4))
+    (require 'cl)))
+
 ;; ==================================================================
 ;; c# upfront stuff
 ;; ==================================================================


### PR DESCRIPTION
There is a error about cl.el function when byte-compiling or loading csharp-mode.el on Emacs 24.4 and Emacs 24.5.

```
csharp-mode.el:1401:1:Error: Symbol's function definition is void: set-difference
```

This is related to Emacs bug 18845.
- https://lists.gnu.org/archive/html/bug-gnu-emacs/2014-10/msg01175.html

See also
- http://stackoverflow.com/questions/32777456/emacs-csharp-mode-definition-is-void-set-difference
