### PR TITLE
Fontify conversion operators definitions. Fontify base interfaces names for 'interface' and 'struct'

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1189,7 +1189,7 @@ a square parentasis block [ ... ]."
 
 
 (c-lang-defconst c-colon-type-list-kwds
-  csharp '("class"))
+  csharp '("class" "struct" "interface"))
 
 (c-lang-defconst c-block-prefix-disallowed-chars
 
@@ -1273,6 +1273,7 @@ a square parentasis block [ ... ]."
 (c-lang-defconst c-modifier-kwds
   csharp '("public" "partial" "private" "const" "abstract" "sealed"
            "protected" "ref" "out" "static" "virtual"
+           "implicit" "explicit" "fixed"
            "override" "params" "internal" "async"))
 
 
@@ -1285,10 +1286,16 @@ a square parentasis block [ ... ]."
   ;; csharp '("private" "protected" "public" "internal")
 )
 
+(c-lang-defconst c-opt-op-identifier-prefix
+  "Regexp matching the token before the ones in
+`c-overloadable-operators' when operators are specified in their \"identifier form\".
+
+This regexp is assumed to not match any non-operator identifier."
+  csharp (c-make-keywords-re t '("operator")))
 
 ;; Define the keywords that can have something following after them.
 (c-lang-defconst c-type-list-kwds
-  csharp '("struct" "class" "interface" "is" "as"
+  csharp '("struct" "class" "interface" "is" "as" "operator"
            "delegate" "event" "set" "get" "add" "remove"))
 
 ;; Handle typeless variable declaration
@@ -1312,6 +1319,7 @@ a square parentasis block [ ... ]."
 ;; Statement keywords followed by a paren sexp and then by a substatement.
 (c-lang-defconst c-block-stmt-2-kwds
   csharp '("for" "if" "switch" "while" "catch" "foreach" "using"
+           "fixed"
            "checked" "unchecked" "lock"))
 
 
@@ -1330,7 +1338,7 @@ a square parentasis block [ ... ]."
 
 ;; Keywords that start "primary expressions."
 (c-lang-defconst c-primary-expr-kwds
-  csharp '("this" "base"))
+  csharp '("this" "base" "operator"))
 
 ;; Treat namespace as an outer block so class indenting
 ;; works properly.


### PR DESCRIPTION
Enable correct fontification for conversion operator declarations like:
'public static implicit operator Foo(Bar value) { ...'
where "implicit", "explicit", and "operator" are fontified as keywords, while "Foo" as a type.

Enable fontification of base interfaces names for "interface" and "struct" declarations, like:
'public interface IFoo : IBar { ...'
'public struct Foo : IBar { ...'
(in the current version,  there only "class" declarations has correctly fontified bases)