### PR TITLE
Fixed fontification hanging on a large file (3kLOC).

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1486,7 +1486,7 @@ Most other csharp functions are not instrumented.
          "\\([[:alpha:]_][^\t\(\n]+\\)"               ;; 2. return type - possibly generic
          "[ \t\n\r\f\v]+"
          "\\([[:alpha:]_][[:alnum:]_]*"               ;; 3. begin name of func
-         "\\(?:<\\(?:[[:alpha:]][[:alnum:]]*[, ]?\\)*>\\)?"  ;; (with optional generic type parameter(s)
+         "\\(?:<\\(?:[[:alpha:]][[:alnum:]]*\\)\\(?:[, ]+[[:alpha:]][[:alnum:]]*\\)*>\\)?"  ;; (with optional generic type parameter(s)
          "\\)"                                        ;; 3. end of name of func
          "[ \t\n\r\f\v]*"
          "\\(\([^\)]*\)\\)"                           ;; 4. params w/parens


### PR DESCRIPTION
With the latest csharp-mode from melpa on Emacs 24.5.1 for Windows, I started pegging the CPU loading a large C# file. It took several seconds to load that file before, but now it appears to not be stopping.

Bisect traced the regression to commit ae1e36c2276a.

I'm not entirely sure what the problem is, but the attached patch rearranges the regexp enough to fix it. Thank you for considering the patch.