### PR TITLE
csharp-mode-map does not derive from prog-mode-map

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1446,6 +1446,7 @@ This regexp is assumed to not match any non-operator identifier."
     ("finally" "finally" c-electric-continued-statement 0)))
 
 (defvar csharp-mode-map (let ((map (c-make-inherited-keymap)))
+                          (set-keymap-parent map prog-mode-map)
                           ;; Add bindings which are only useful for C#
                           map)
   "Keymap used in csharp-mode buffers.")


### PR DESCRIPTION
`csharp-mode-map` does not derive from `prog-mode-map` which makes my bindings in `prog-mode-map` not work (specifically company-, realgud-, and iedit integrations that is agnostic to the specific programming language).

This is similar to [this bug report](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=14504) which indicates that adding something like `(set-keymap-parent map prog-mode-map)` at the correct location should fix it.