### PR TITLE
Issue #112: Allow whitespace after the `#` in a directive.

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -386,6 +386,17 @@
   (forward-word -1)
   (should (looking-at "fontifies")))
 
+(ert-deftest fontification-of-regions ()
+  (require 'assess)
+  (require 'm-buffer)
+  (find-file "test-files/region-fontification.cs")
+  (csharp-mode)
+  (let ((buf (current-buffer)))
+    ;; look for 'a region comment' - should always be a comment
+    (should (assess-face-at= buf 'csharp-mode (lambda (buf) (m-buffer-match buf "a region comment")) 'font-lock-comment-face))
+    ;; look for 'string' - should always be a type
+    (should (assess-face-at= buf 'csharp-mode (lambda (buf) (m-buffer-match buf "string")) 'font-lock-type-face))))
+
 ;;(ert-run-tests-interactively t)
 ;; (local-set-key (kbd "<f6>") '(lambda ()
 ;;                               (interactive)

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1155,9 +1155,9 @@ Currently handled:
                   (setq done t)))))))))
 
     (goto-char beg)
-    (while (re-search-forward "^\\s *#\\s *\\(region\\|pragma\\) " end t)
-      (when (looking-at "\\w")
-        ;; mark the space separating the directive from the comment
+    (while (re-search-forward "^\\s *#\\s *\\(region\\|pragma\\)\\s " end t)
+      (when (looking-at "\\s *\\S ")
+        ;; mark the whitespace separating the directive from the comment
         ;; text as comment starter to allow correct word movement
         (put-text-property (1- (point)) (point)
                            'syntax-table (string-to-syntax "< b"))))))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1054,7 +1054,7 @@ to work properly with code that includes attributes."
                                          (save-excursion
                                            (c-beginning-of-statement-1)
                                            (looking-at
-                                            "#\\(pragma\\|endregion\\|region\\|if\\|else\\|endif\\)"))
+                                            "#\\s *\\(pragma\\|endregion\\|region\\|if\\|else\\|endif\\)"))
                                          )))
 
                         (if is-attr
@@ -1155,7 +1155,7 @@ Currently handled:
                   (setq done t)))))))))
 
     (goto-char beg)
-    (while (re-search-forward "^\\s-*#\\(region\\|pragma\\) " end t)
+    (while (re-search-forward "^\\s *#\\s *\\(region\\|pragma\\) " end t)
       (when (looking-at "\\w")
         ;; mark the space separating the directive from the comment
         ;; text as comment starter to allow correct word movement
@@ -1403,7 +1403,7 @@ This regexp is assumed to not match any non-operator identifier."
           ;; Use the eval form for `font-lock-keywords' to be able to use
           ;; the `c-preprocessor-face-name' variable that maps to a
           ;; suitable face depending on the (X)Emacs version.
-          '(eval . (list "^\\s *\\(#pragma\\|undef\\|define\\)\\>\\(.*\\)"
+          '(eval . (list "^\\s *#\\s *\\(pragma\\|undef\\|define\\)\\>\\(.*\\)"
                          (list 1 c-preprocessor-face-name)
                          '(2 font-lock-string-face)))
           ;; There are some other things in `c-cpp-matchers' besides the

--- a/test-files/region-fontification.cs
+++ b/test-files/region-fontification.cs
@@ -4,11 +4,40 @@ public class Test
 {
     public void Test()
     {
-        #region fontifies correctly
+        #region fontifies as a region comment
         string foo = "bar";
         #endregion
         
-        #region does'nt fontify correctly
+        #region quotes shouldn't mess up a region comment
+        string foo = "bar";
+        #endregion
+        
+        #region   any number of spaces are allowed before a region comment
+        string foo = "bar";
+        #endregion
+        
+        #region	a TAB is also allowed before a region comment
+        string foo = "bar";
+        #endregion
+
+        #  region a region comment is fine when there are spaces between the # and the region
+        string foo = "bar";
+        #  endregion
+        
+        #	region a TAB between the # and the region doesn't stop this being a region comment either
+        string foo = "bar";
+        #	endregion
+
+        #region --- a region comment doesn't have to start with a word ---
+        string foo = "bar";
+        #endregion
+
+        #region "a region comment can even look like this"
+        string foo = "bar";
+        #endregion
+
+        // This is here just to ensure the commentification doesn't bleed to the next line
+        #region
         string foo = "bar";
         #endregion
     }


### PR DESCRIPTION
This also changes a use of "\\s-" to "\\s ", because the latter form is equivalent and was used more often elsewhere in the file.

The \\(#pragma\\|define\\|undef\\) seemed suspect so I moved the `#` out of the group and added optional whitespace after it.