### PR TITLE
communicate default style safely

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -397,6 +397,33 @@
     ;; look for 'string' - should always be a type
     (should (assess-face-at= buf 'csharp-mode (lambda (buf) (m-buffer-match buf "string")) 'font-lock-type-face))))
 
+(ert-deftest activating-mode-doesnt-clobber-global-adaptive-fill-regexp ()
+  (let ((before adaptive-fill-regexp))
+    (with-temp-buffer
+      (csharp-mode))
+    (should
+     (equal before adaptive-fill-regexp))
+  ))
+
+(ert-deftest activating-mode-style-defaults-to-csharp ()
+  (let ((c-default-style "defaultc#"))
+    (with-temp-buffer
+      (csharp-mode)
+      (should
+       (equal "defaultc#" c-indentation-style))))
+  (let ((c-default-style '((csharp-mode . "defaultc#fromlist")
+                           (java-mode . "defaultjava"))))
+    (with-temp-buffer
+      (csharp-mode)
+      (should
+       (equal "defaultc#fromlist" c-indentation-style))))
+  (let (c-default-style)
+    (with-temp-buffer
+      (csharp-mode)
+      (should
+       (equal "C#" c-indentation-style))
+      )))
+
 ;;(ert-run-tests-interactively t)
 ;; (local-set-key (kbd "<f6>") '(lambda ()
 ;;                               (interactive)

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -402,8 +402,7 @@
     (with-temp-buffer
       (csharp-mode))
     (should
-     (equal before adaptive-fill-regexp))
-  ))
+     (equal before adaptive-fill-regexp))))
 
 (ert-deftest activating-mode-style-defaults-to-csharp ()
   (let ((c-default-style "defaultc#"))
@@ -421,8 +420,7 @@
     (with-temp-buffer
       (csharp-mode)
       (should
-       (equal "C#" c-indentation-style))
-      )))
+       (equal "C#" c-indentation-style)))))
 
 ;;(ert-run-tests-interactively t)
 ;; (local-set-key (kbd "<f6>") '(lambda ()

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2968,9 +2968,10 @@ Key bindings:
   ;; customized values for our language.
   (c-init-language-vars csharp-mode)
 
-  ;; Set style to c# style unless a file local variable or default
-  ;; style is found, in which case it should be set after
-  ;; calling `c-common-init' below.
+  ;; Use our predefined "C#" style unless a file local or default
+  ;; style is found. This is done by rebinding `c-default-style'
+  ;; during the `c-common-init' call. 'c-common-init' will initialize
+  ;; the buffer's style using the value of `c-default-style'.
   (let ((c-default-style (if (or c-file-style
                                  (stringp c-default-style)
                                  (assq 'csharp-mode c-default-style))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2971,17 +2971,17 @@ Key bindings:
   ;; Set style to c# style unless a file local variable or default
   ;; style is found, in which case it should be set after
   ;; calling `c-common-init' below.
-  (unless (or c-file-style
-              (stringp c-default-style)
-              (assq 'csharp-mode c-default-style))
-    (c-set-style "C#" 'do-not-override-customized-values))
-
-  ;; `c-common-init' initializes most of the components of a CC Mode
-  ;; buffer, including setup of the mode menu, font-lock, etc.
-  ;; There's also a lower level routine `c-basic-common-init' that
-  ;; only makes the necessary initialization to get the syntactic
-  ;; analysis and similar things working.
-  (c-common-init 'csharp-mode)
+  (let ((c-default-style (if (or c-file-style
+                                 (stringp c-default-style)
+                                 (assq 'csharp-mode c-default-style))
+                             c-default-style
+                           "C#")))
+    ;; `c-common-init' initializes most of the components of a CC Mode
+    ;; buffer, including setup of the mode menu, font-lock, etc.
+    ;; There's also a lower level routine `c-basic-common-init' that
+    ;; only makes the necessary initialization to get the syntactic
+    ;; analysis and similar things working.
+    (c-common-init 'csharp-mode))
 
   (define-key csharp-mode-map (kbd "/") 'csharp-maybe-insert-codedoc)
 


### PR DESCRIPTION
if no explicit style was specified csharp-mode called c-set-style to set style "C#". But this caused a lot of cc-mode code to be executed before initializing cc-mode, causing trouble (see issue #117).

This change achieves the intended effect in a different way. It binds "C#" to c-default-style for the duration of c-common-init if no explicit style was specified and lets nature take its course.