### PR TITLE
Add csharp group definition

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -365,6 +365,10 @@
 ;;      :test 'equal)))
 
 
+(defgroup csharp nil
+  "Major mode for editing C# code."
+  :group 'prog-mode)
+
 
 ;; Custom variables
 ;; ensure all are defined before using ...;


### PR DESCRIPTION
The definition was missing.  Therefore, the group was not reachable from the customization interface.