### PR TITLE
Advise c-inside-bracelist-p (#122)

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -422,6 +422,13 @@
       (should
        (equal "C#" c-indentation-style)))))
 
+(ert-deftest inside-bracelist-test ()
+  (let ((c-default-style "defaultc#"))
+    (with-temp-buffer
+      (csharp-mode)
+      (insert "public class A { public void F() {")
+      (call-interactively #'newline))))
+
 ;;(ert-run-tests-interactively t)
 ;; (local-set-key (kbd "<f6>") '(lambda ()
 ;;                               (interactive)

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2576,11 +2576,18 @@ are the string substitutions (see `format')."
 
         res))))
 
+(advice-add 'c-inside-bracelist-p
+            :around 'csharp-inside-bracelist-or-c-inside-bracelist-p)
 
+(defun csharp-inside-bracelist-or-c-inside-bracelist-p (command &rest args)
+  "Run `csharp-inside-bracelist-p' if in `csharp-mode'.
 
+Otherwise run `c-inside-bracelist-p'."
+  (if (eq major-mode 'csharp-mode)
+      (csharp-inside-bracelist-p (nth 0 args) (nth 1 args))
+    (apply command args)))
 
-
-(defun c-inside-bracelist-p (containing-sexp paren-state)
+(defun csharp-inside-bracelist-p (containing-sexp paren-state)
   ;; return the buffer position of the beginning of the brace list
   ;; statement if we're inside a brace list, otherwise return nil.
   ;; CONTAINING-SEXP is the buffer pos of the innermost containing


### PR DESCRIPTION
https://github.com/josteink/csharp-mode/issues/122

Heads-up: I have failed tests with/without this change.

Not sure if there was something special to do, I just ran 'make test'.

```
Ran 28 tests, 19 results as expected, 9 unexpected (2017-12-10 22:42:13-0800)

9 unexpected results:
   FAILED  fontification-of-compiler-directives
   FAILED  fontification-of-compiler-directives-after-comments
   FAILED  fontification-of-literals-allows-multi-line-strings
   FAILED  fontification-of-literals-detects-end-of-strings
   FAILED  fontification-of-method-names
   FAILED  fontification-of-namespace-statements
   FAILED  fontification-of-regions
   FAILED  fontification-of-using-statements
   FAILED  indentation-rules-should-be-as-specified-in-test-doc

make: *** [test] Error 1
```