### PR TITLE
Protect dmode from ccmode monkeypatch

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2509,12 +2509,12 @@ are the string substitutions (see `format')."
 	   (c-put-font-lock-face start (1+ start) 'font-lock-warning-face)))))
 
 (advice-add 'c-looking-at-inexpr-block
-	    :around 'csharp--c-looking-at-inexpr-block-hack)
+            :around 'csharp--c-looking-at-inexpr-block-hack)
 
 (defun csharp--c-looking-at-inexpr-block-hack (orig-fun &rest args)
   (apply
-   (if csharp-mode
-       csharp--c-looking-at-inexpr-block
+   (if (eq major-mode 'csharp-mode)
+       #'csharp--c-looking-at-inexpr-block
      orig-fun)
    args))
 
@@ -3108,4 +3108,3 @@ Key bindings:
 (provide 'csharp-mode)
 
 ;;; csharp-mode.el ends here
-

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -3077,10 +3077,10 @@ Key bindings:
 
   ;; The paragraph-separate variable was getting stomped by
   ;; other hooks, so it must reside here.
-  (set (make-local-variable paragraph-separate)
-        "[ \t]*\\(//+\\|\\**\\)\\([ \t]+\\|[ \t]+<.+?>\\)$\\|^\f")
+  (setq-local paragraph-separate
+              "[ \t]*\\(//+\\|\\**\\)\\([ \t]+\\|[ \t]+<.+?>\\)$\\|^\f")
 
-  (set (make-local-variable beginning-of-defun-function) 'csharp-move-back-to-beginning-of-defun)
+  (setq-local beginning-of-defun-function 'csharp-move-back-to-beginning-of-defun)
   ;; `end-of-defun-function' can remain forward-sexp !!
 
   (set (make-local-variable 'comment-auto-fill-only-comments) t)

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2508,7 +2508,17 @@ are the string substitutions (see `format')."
 	     t)
 	   (c-put-font-lock-face start (1+ start) 'font-lock-warning-face)))))
 
-(defun c-looking-at-inexpr-block (lim containing-sexp &optional check-at-end)
+(advice-add 'c-looking-at-inexpr-block
+	    :around 'csharp--c-looking-at-inexpr-block-hack)
+
+(defun csharp--c-looking-at-inexpr-block-hack (orig-fun &rest args)
+  (funcall
+   (if csharp-mode
+       csharp--c-looking-at-inexpr-block
+     orig-fun)
+   args))
+
+(defun csharp--c-looking-at-inexpr-block (lim containing-sexp &optional check-at-end)
   ;; Return non-nil if we're looking at the beginning of a block
   ;; inside an expression.  The value returned is actually a cons of
   ;; either 'inlambda, 'inexpr-statement or 'inexpr-class and the

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -3077,10 +3077,10 @@ Key bindings:
 
   ;; The paragraph-separate variable was getting stomped by
   ;; other hooks, so it must reside here.
-  (setq paragraph-separate
+  (set (make-local-variable paragraph-separate)
         "[ \t]*\\(//+\\|\\**\\)\\([ \t]+\\|[ \t]+<.+?>\\)$\\|^\f")
 
-  (setq beginning-of-defun-function 'csharp-move-back-to-beginning-of-defun)
+  (set (make-local-variable beginning-of-defun-function) 'csharp-move-back-to-beginning-of-defun)
   ;; `end-of-defun-function' can remain forward-sexp !!
 
   (set (make-local-variable 'comment-auto-fill-only-comments) t)

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2512,8 +2512,8 @@ are the string substitutions (see `format')."
 	    :around 'csharp--c-looking-at-inexpr-block-hack)
 
 (defun csharp--c-looking-at-inexpr-block-hack (orig-fun &rest args)
-  (funcall
-   (if csharp-mode
+  (apply
+   (if (and (boundp 'csharp-mode) csharp-mode)
        csharp--c-looking-at-inexpr-block
      orig-fun)
    args))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2513,7 +2513,7 @@ are the string substitutions (see `format')."
 
 (defun csharp--c-looking-at-inexpr-block-hack (orig-fun &rest args)
   (apply
-   (if (and (boundp 'csharp-mode) csharp-mode)
+   (if csharp-mode
        csharp--c-looking-at-inexpr-block
      orig-fun)
    args))


### PR DESCRIPTION
Try to apply redefinitions only in csharp-mode, and not globally.

