### PR TITLE
Fix font lock breaks on strings #151

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -2461,12 +2461,15 @@ are the string substitutions (see `format')."
   )
 
 (defadvice c-clear-string-fences (around
-                                  csharp-mode-advice-3
+                                  csharp-disable-clear-string-fences
                                   compile activate)
-  "Disable because it breaks csharp-mode when quoting. See
-https://github.com/josteink/csharp-mode/issues/151"
+  "This turns off `c-clear-string-fences' for `csharp-mode'. When
+on for `csharp-mode' font lock breaks after an interpolated
+string or terminating simple string."
   (if (c-major-mode-is 'csharp-mode)
-      ()))
+      nil
+    ad-do-it)
+  )
 
 ;; ==================================================================
 ;; end of C#-specific optimizations of cc-mode funcs

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1146,9 +1146,6 @@ to work properly with code that includes attributes."
 (c-lang-defconst c-multiline-string-start-char
   csharp ?@)
 
-(defun c-clear-string-fences ()
-  "Function is made null because it breaks csharp-mode when quoting. See https://github.com/josteink/csharp-mode/issues/151")
-
 (defun csharp-mode-syntax-propertize-function (beg end)
   "Apply syntax table properties to special constructs in region BEG to END.
 Currently handled:
@@ -2462,6 +2459,14 @@ are the string substitutions (see `format')."
       nil
     ad-do-it)
   )
+
+(defadvice c-clear-string-fences (around
+                                  csharp-mode-advice-3
+                                  compile activate)
+  "Disable because it breaks csharp-mode when quoting. See
+https://github.com/josteink/csharp-mode/issues/151"
+  (if (c-major-mode-is 'csharp-mode)
+      ()))
 
 ;; ==================================================================
 ;; end of C#-specific optimizations of cc-mode funcs

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1146,6 +1146,9 @@ to work properly with code that includes attributes."
 (c-lang-defconst c-multiline-string-start-char
   csharp ?@)
 
+(defun c-clear-string-fences ()
+  "Function is made null because it breaks csharp-mode when quoting. See https://github.com/josteink/csharp-mode/issues/151")
+
 (defun csharp-mode-syntax-propertize-function (beg end)
   "Apply syntax table properties to special constructs in region BEG to END.
 Currently handled:


### PR DESCRIPTION
Font lock breaks after an interpolated string or terminating simple string.

Fix provided by phoenixanimations.