### PR TITLE
Fix display of ‘package’ as any sort of name

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -67,6 +67,18 @@
    "value" 'font-lock-constant-face
    ))
 
+(ert-deftest fontification-of-package ()
+  (require 'assess)
+  (assess-face-in-text=
+   "var package = true;"
+   "package" 'font-lock-variable-name-face))
+
+(ert-deftest fontification-of-import ()
+  (require 'assess)
+  (assess-face-in-text=
+   "var import = true;"
+   "import" 'font-lock-variable-name-face))
+
 (ert-deftest fontification-of-literals-allows-multi-line-strings ()
   (require 'assess)
   (should (assess-face-at=

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -1399,6 +1399,12 @@ This regexp is assumed to not match any non-operator identifier."
 (c-lang-defconst c-other-block-decl-kwds
   csharp '("namespace"))
 
+(c-lang-defconst c-ref-list-kwds
+  csharp nil)
+
+(c-lang-defconst c-other-decl-kwds
+  csharp nil)
+
 (c-lang-defconst c-other-kwds
   csharp '("sizeof" "typeof" "is" "as" "yield"
            "where" "select" "in" "from" "let" "orderby" "ascending" "descending"


### PR DESCRIPTION
‘java-mode’ sets up "package" to be displayed as a keyword using both the
‘c-ref-list-kwds’ and ‘c-other-decl-kwds’. Override these constants for
‘csharp-mode’ so that a variable named ‘package’ doesn’t show up as a keyword.

Because both constants are set to nil this also removes "import" from the list
of keywords.

This fixes my issue (#158) I ran the tests but I didn't do a thorough test of using this version of the package on some real C# code. I don't know if either of these should define any other keywords (such as using) because at the moment the descriptions of these constants seem a bit abstract and I don't fully understand what they're for.