### PR TITLE
Make fontification a little less 'constant-heavy'

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -162,9 +162,9 @@
                         "using" 'font-lock-keyword-face
                         "Reference" 'font-lock-type-face
                         "Under_scored" 'font-lock-type-face
-                        "WithNumbers09" 'font-lock-constant-face
+                        "WithNumbers09" 'font-lock-variable-name-face
                         "Ok" 'font-lock-type-face
-                        "WithNumbers09" 'font-lock-constant-face
+                        "WithNumbers09" 'font-lock-variable-name-face
                         "OkV2" 'font-lock-type-face
                         ))
 
@@ -173,9 +173,9 @@
                         "namespace" 'font-lock-keyword-face
                         "Reference" 'font-lock-type-face
                         "Under_scored" 'font-lock-type-face
-                        "WithNumbers09" 'font-lock-constant-face
+                        "WithNumbers09" 'font-lock-variable-name-face
                         "Ok" 'font-lock-type-face
-                        "WithNumbers09" 'font-lock-constant-face
+                        "WithNumbers09" 'font-lock-variable-name-face
                         "Ok" 'font-lock-type-face
                         ))
 

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -90,6 +90,14 @@
    "var package = true;"
    "package" 'font-lock-variable-name-face))
 
+(ert-deftest fontification-of-functions ()
+  (require 'assess)
+  (assess-face-in-text= "var foo = bar.Baz()"
+                        "Baz" 'font-lock-function-name-face)
+  (assess-face-in-text= "var foo = bar.Baz<Quux>()"
+                        "Baz" 'font-lock-function-name-face
+                        "Quux" 'font-lock-type-face))
+
 (ert-deftest fontification-of-import ()
   (require 'assess)
   (assess-face-in-text=

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -298,7 +298,7 @@ casts and declarations are fontified.  Used on level 2 and higher."
           (c-lang-const c-basic-matchers-after)
 
           ;; function names
-          `(("\\.\\([A-Za-z0-9_]+\\)(" 1 font-lock-function-name-face t))
+          `(("\\.\\([A-Za-z0-9_]+\\)[<(]" 1 font-lock-function-name-face t))
           ))
 
 (defcustom csharp-font-lock-extra-types

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -53,12 +53,6 @@
   csharp (append '((?@ . "w"))
 	         (c-lang-const c-identifier-syntax-modifications)))
 
-(c-lang-defconst c-basic-matchers-after
-  csharp (append nil
-     ;; cc-mode defaults
-     (c-lang-const c-basic-matchers-after)))
-
-
 (c-lang-defconst c-symbol-start
   csharp (concat "[" c-alpha "_@]"))
 
@@ -297,6 +291,15 @@ casts and declarations are fontified.  Used on level 2 and higher."
 
            (eval . (list "\\(!\\)[^=]" 1 c-negation-char-face-name))
            ))
+
+(c-lang-defconst c-basic-matchers-after
+  csharp (append
+          ;; merge with cc-mode defaults
+          (c-lang-const c-basic-matchers-after)
+
+          ;; function names
+          `(("\\.\\([A-Za-z0-9_]+\\)(" 1 font-lock-function-name-face t))
+          ))
 
 (defcustom csharp-font-lock-extra-types
   (list (concat "[" c-upper "]\\sw*[" c-lower "]\\sw"))


### PR DESCRIPTION
However, for this one, I'd like for you to take a look and test :)

This tries to lighten up a little on #169 with choosing variable-name-face, rather than the constant name face which is the default. This makes the fontification a little more similar to how vscode looks without directly disabling fontification.

Of course, these things are color scheme dependent, and also on taste and such. Personally, I agree on the constant face being a little heavy (on my colorscheme), and this lightens it up a little.

@josteink What do you think?