### PR TITLE
Add annotation-top-cont as a new syntax construct

### DIFF
--- a/test-files/indentation-tests.cs
+++ b/test-files/indentation-tests.cs
@@ -238,3 +238,20 @@ enum AnotherEnum
     Second = 2,
     Third = 3
 }
+
+public async Task WriteAsync()
+{
+    using (var memoryStream = new MemoryStream())
+    using (var writer = new BinaryWriter())
+    {
+        // double using should indent like this
+    }
+
+    using (var memoryStream = new MemoryStream())
+    {
+        using (var writer = new BinaryWriter())
+        {
+            // or this
+        }
+    }
+}


### PR DESCRIPTION
#142 - not fixing this yet, but it is adding a new construct, the same as `java-mode` is using for a similar matter

@josteink, can you take a look at this and see if this indents correctly, and creates a new syntax construct? Also, if this is completely bonkers :P

`C-c C-s` when point is on picture should give us the new construct, and indent correctly. No need for ugly vsemi hack. It should also work with multiple attributes below eachother.

![image](https://user-images.githubusercontent.com/26711805/95197691-46619f80-07da-11eb-9322-ae97dc1a9e15.png)
