### PR TITLE
Extend support for .NET Core in our compilation-mode regexps

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -237,7 +237,12 @@
                "C:\\inservice\\SystemTesting\\OperateDeviceProxy\\OperateDevice_Proxy\\Program.cs"
                "c:\\inservice\\systemtesting\\operationsproxy\\operationsproxy.cpp"
                "c:\\inservice\\systemtesting\\operationsproxy\\operationsproxy.cpp"
-               "c:\\inservice\\systemtesting\\operationsproxy\\operationsproxy.cpp"))))
+               "c:\\inservice\\systemtesting\\operationsproxy\\operationsproxy.cpp"))
+
+             ("./test-files/dotnet-nuget-error.txt" ,csharp-compilation-re-dotnet-error
+              ("/home/jostein/build/sample-app/sample-app.csproj"))
+             ("./test-files/dotnet-nuget-warning.txt" ,csharp-compilation-re-dotnet-warning
+              ("/home/jostein/build/sample-app/sample-app.csproj"))))
 
     (let* ((file-name (car test-case))
            (regexp    (cadr test-case))

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -242,7 +242,9 @@
              ("./test-files/dotnet-nuget-error.txt" ,csharp-compilation-re-dotnet-error
               ("/home/jostein/build/sample-app/sample-app.csproj"))
              ("./test-files/dotnet-nuget-warning.txt" ,csharp-compilation-re-dotnet-warning
-              ("/home/jostein/build/sample-app/sample-app.csproj"))))
+              ("/home/jostein/build/sample-app/sample-app.csproj"))
+             ("./test-files/dotnet-test-fail-xunit.txt" ,csharp-compilation-re-dotnet-testfail
+              ("/home/jostein/build/sample-app/Module/Testee.cs"))))
 
     (let* ((file-name (car test-case))
            (regexp    (cadr test-case))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -370,6 +370,13 @@ casts and declarations are fontified.  Used on level 2 and higher."
    "warning [[:alnum:]]+: .+$")
   "Regexp to match compilation warning from xbuild.")
 
+(defconst csharp-compilation-re-dotnet-error
+  "\\([^\r\n]+\\) : error [A-Z]+[0-9]+:")
+
+(defconst csharp-compilation-re-dotnet-warning
+  "\\([^\r\n]+\\) : warning [A-Z]+[0-9]+:")
+
+
 (eval-after-load 'compile
   (lambda ()
     (dolist
@@ -397,7 +404,13 @@ casts and declarations are fontified.  Used on level 2 and higher."
             1
             nil
             (1 compilation-warning-face)
-            (4 compilation-warning-face))))
+            (4 compilation-warning-face))
+           (dotnet-error
+            ,csharp-compilation-re-dotnet-error
+            1)
+           (dotnet-warning
+            ,csharp-compilation-re-dotnet-warning
+            1 nil nil 1)))
       (add-to-list 'compilation-error-regexp-alist-alist regexp)
       (add-to-list 'compilation-error-regexp-alist (car regexp)))))
 

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -376,6 +376,12 @@ casts and declarations are fontified.  Used on level 2 and higher."
 (defconst csharp-compilation-re-dotnet-warning
   "\\([^\r\n]+\\) : warning [A-Z]+[0-9]+:")
 
+(defconst csharp-compilation-re-dotnet-testfail
+  (concat
+   "\\[[A-Za-z.]+[[:blank:]]+[0-9]+:[0-9]+:[0-9]+.[0-9]+\\][^(\r\n)]+ \\[FAIL\\]\n"
+   "[[:blank:]]+X \\(?:.+\n\\)+"
+   "[[:blank:]]+Stack Trace:\n"
+   "[[:blank:]]+at [^\r\n]+ in \\([^\r\n]+\\):line \\([0-9]+\\)"))
 
 (eval-after-load 'compile
   (lambda ()
@@ -410,7 +416,10 @@ casts and declarations are fontified.  Used on level 2 and higher."
             1)
            (dotnet-warning
             ,csharp-compilation-re-dotnet-warning
-            1 nil nil 1)))
+            1 nil nil 1)
+           (dotnet-testfail
+            ,csharp-compilation-re-dotnet-testfail
+            1 2)))
       (add-to-list 'compilation-error-regexp-alist-alist regexp)
       (add-to-list 'compilation-error-regexp-alist (car regexp)))))
 

--- a/test-files/dotnet-nuget-error.txt
+++ b/test-files/dotnet-nuget-error.txt
@@ -1,0 +1,1 @@
+/home/jostein/build/sample-app/sample-app.csproj : error NU1102:   - Found 24 version(s) in Net5 [ Nearest version: 5.0.0-rc.2.20513.86 ] [/home/jostein/build/sample-app/sample-app.sln]

--- a/test-files/dotnet-nuget-warning.txt
+++ b/test-files/dotnet-nuget-warning.txt
@@ -1,0 +1,1 @@
+/home/jostein/build/sample-app/sample-app.csproj : warning NU1604: Project dependency JetBrains.Annotations does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.

--- a/test-files/dotnet-test-fail-xunit.txt
+++ b/test-files/dotnet-test-fail-xunit.txt
@@ -1,0 +1,8 @@
+[xUnit.net 00:00:00.60]     SampleApp.Module.Tests.TestClass.Some_Testcase_Gone_Wrong [FAIL]
+  X SampleApp.Module.Tests.TestClass.Some_Testcase_Gone_Wrong [2ms]
+  Error Message:
+   System.NotImplementedException : The method or operation is not implemented.
+  Stack Trace:
+     at SampleApp.Module.Testee..ctor(IHttpClient httpClient) in /home/jostein/build/sample-app/Module/Testee.cs:line 24
+   at SampleApp.Module.Tests.TestClass.Some_Testcase_Gone_Wrong() in /home/jostein/build/sample-app/tests/TestClass.cs:line 11
+ 


### PR DESCRIPTION
This PR adds extended support to the existing `compilation-mode` support in `csharp-mode` w.r.t. .NET Core and the associated toolchain.

Primarily it adds support for various non-compiler/non-Roslyn errors you may encounter when running `dotnet build` or `dotnet test`:

- nuget restore errors
- nuget package warning
- test-failures (tested with xUnit)

I've included test-cases for all these different failures.

Notable for each new addition:

- nuget restore errors: only csproj-file is provided in the output, not exact line-number, so we cannot match on that.
- nuget restore warnings: same.
- test-failures: provides full stack-trace, including file-name and line-number per stack-frame. I've made the decision to target the top-most stack-frame where the error happened, and not the bottom-most one (which would be where in the test-method it failed). If people have an issue with that, it should be fairly easy to switch around.

All good? Any opinions?